### PR TITLE
Added open scene button

### DIFF
--- a/addons/scene_manager/scene_item.gd
+++ b/addons/scene_manager/scene_item.gd
@@ -96,7 +96,12 @@ func _on_popup_button_button_up():
 	var popup_size = _popup_menu.size
 	_popup_menu.popup(Rect2(get_global_mouse_position(), popup_size))
 
-# Heppends when an item is selected
+# Open scene
+func _on_open_scene_button_up():
+	var scenePath = get_value()
+	EditorPlugin.new().get_editor_interface().open_scene_from_path(scenePath)
+
+# Happens when an item is selected
 func _on_popup_menu_index_pressed(index: int):
 	var id = _popup_menu.get_item_id(index)
 	var checked = _popup_menu.is_item_checked(index)

--- a/addons/scene_manager/scene_item.tscn
+++ b/addons/scene_manager/scene_item.tscn
@@ -3,6 +3,7 @@
 [ext_resource type="Script" path="res://addons/scene_manager/scene_item.gd" id="2"]
 [ext_resource type="Texture2D" uid="uid://brxxaey30q7uk" path="res://addons/scene_manager/icons/GuiTabMenuHl.svg" id="3"]
 [ext_resource type="Script" path="res://addons/scene_manager/popup_button.gd" id="3_nwus0"]
+[ext_resource type="Texture2D" uid="uid://c7652b22u400p" path="res://addons/scene_manager/icons/eye_open.png" id="4"]
 
 [node name="item" type="HBoxContainer"]
 offset_right = 280.0
@@ -25,6 +26,11 @@ layout_mode = 2
 size_flags_horizontal = 3
 editable = false
 
+[node name="open_button" type="Button" parent="."]
+custom_minimum_size = Vector2(28, 28)
+layout_mode = 2
+icon = ExtResource("4")
+
 [node name="popup_menu" type="PopupMenu" parent="."]
 size = Vector2i(100, 28)
 visible = true
@@ -34,4 +40,5 @@ hide_on_item_selection = false
 [connection signal="tree_exited" from="." to="." method="_on_tree_exited"]
 [connection signal="button_up" from="popup_button" to="." method="_on_popup_button_button_up"]
 [connection signal="gui_input" from="key" to="." method="_on_key_gui_input"]
+[connection signal="button_up" from="open_button" to="." method="_on_open_scene_button_up"]
 [connection signal="index_pressed" from="popup_menu" to="." method="_on_popup_menu_index_pressed"]


### PR DESCRIPTION
I don't know where the icons were originally sourced from, but I've re-used the eye icon
Clicking it will open up that scene in the Godot editor

Example of how it looks:
![image](https://github.com/maktoobgar/scene_manager/assets/25872086/a894732e-af56-44ca-95d6-53f643b86fc4)